### PR TITLE
Implement ephemeral fragment option

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,7 @@ Hopefully the last alpha before a stable release that includes tool support.
 * New `--pre` option for `llm install` to allow installing pre-release packages. ([#1060](https://github.com/simonw/llm/issues/1060))
 * OpenAI models (`gpt-4o`, `gpt-4o-mini`) now explicitly declare support for tools and vision. ([#1037](https://github.com/simonw/llm/issues/1037))
 * The `supports_tools` parameter is now supported in `extra-openai-models.yaml`. Thanks, [Mahesh Hegde ](https://github.com/mahesh-hegde). ([#1068](https://github.com/simonw/llm/issues/1068))
+* New `-ef/--ephemeral-fragment` option adds a fragment to a prompt without storing it in the database.
 
 ### Bug fixes
 

--- a/docs/fragments.md
+++ b/docs/fragments.md
@@ -27,6 +27,10 @@ Here we are specifying a fragment using a URL. The contents of that URL will be 
 
 The `-f` option can be used multiple times to combine together multiple fragments.
 
+If you want to include a fragment without storing it in the database, use
+`-ef/--ephemeral-fragment` instead. This works just like `-f` but the fragment
+is discarded once the prompt finishes executing.
+
 Fragments can also be files on disk, for example:
 ```bash
 llm -f setup.py 'extract the metadata'

--- a/docs/help.md
+++ b/docs/help.md
@@ -138,6 +138,8 @@ Options:
   --schema-multi TEXT             JSON schema to use for multiple results
   -f, --fragment TEXT             Fragment (alias, URL, hash or file path) to
                                   add to the prompt
+  -ef, --ephemeral-fragment TEXT  Fragment to add to the prompt without storing
+                                  it
   --sf, --system-fragment TEXT    Fragment to add to system prompt
   -t, --template TEXT             Template to use
   -p, --param <TEXT TEXT>...      Parameters for template
@@ -163,27 +165,29 @@ Usage: llm chat [OPTIONS]
   Hold an ongoing chat with a model.
 
 Options:
-  -s, --system TEXT             System prompt to use
-  -m, --model TEXT              Model to use
-  -c, --continue                Continue the most recent conversation.
-  --cid, --conversation TEXT    Continue the conversation with the given ID.
-  -f, --fragment TEXT           Fragment (alias, URL, hash or file path) to add
-                                to the prompt
-  --sf, --system-fragment TEXT  Fragment to add to system prompt
-  -t, --template TEXT           Template to use
-  -p, --param <TEXT TEXT>...    Parameters for template
-  -o, --option <TEXT TEXT>...   key/value options for the model
-  -d, --database FILE           Path to log database
-  --no-stream                   Do not stream output
-  --key TEXT                    API key to use
-  -T, --tool TEXT               Name of a tool to make available to the model
-  --functions TEXT              Python code block or file path defining
-                                functions to register as tools
-  --td, --tools-debug           Show full details of tool executions
-  --ta, --tools-approve         Manually approve every tool execution
-  --cl, --chain-limit INTEGER   How many chained tool responses to allow,
-                                default 5, set 0 for unlimited
-  -h, --help                    Show this message and exit.
+  -s, --system TEXT               System prompt to use
+  -m, --model TEXT                Model to use
+  -c, --continue                  Continue the most recent conversation.
+  --cid, --conversation TEXT      Continue the conversation with the given ID.
+  -f, --fragment TEXT             Fragment (alias, URL, hash or file path) to
+                                  add to the prompt
+  -ef, --ephemeral-fragment TEXT  Fragment to add to the prompt without storing
+                                  it
+  --sf, --system-fragment TEXT    Fragment to add to system prompt
+  -t, --template TEXT             Template to use
+  -p, --param <TEXT TEXT>...      Parameters for template
+  -o, --option <TEXT TEXT>...     key/value options for the model
+  -d, --database FILE             Path to log database
+  --no-stream                     Do not stream output
+  --key TEXT                      API key to use
+  -T, --tool TEXT                 Name of a tool to make available to the model
+  --functions TEXT                Python code block or file path defining
+                                  functions to register as tools
+  --td, --tools-debug             Show full details of tool executions
+  --ta, --tools-approve           Manually approve every tool execution
+  --cl, --chain-limit INTEGER     How many chained tool responses to allow,
+                                  default 5, set 0 for unlimited
+  -h, --help                      Show this message and exit.
 ```
 
 (help-keys)=

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -428,6 +428,13 @@ def cli():
     help="Fragment (alias, URL, hash or file path) to add to the prompt",
 )
 @click.option(
+    "ephemeral_fragments",
+    "-ef",
+    "--ephemeral-fragment",
+    multiple=True,
+    help="Fragment to add to the prompt without storing it",
+)
+@click.option(
     "system_fragments",
     "--sf",
     "--system-fragment",
@@ -488,6 +495,7 @@ def prompt(
     schema_input,
     schema_multi,
     fragments,
+    ephemeral_fragments,
     system_fragments,
     template,
     param,
@@ -805,6 +813,16 @@ def prompt(
             for attachment in fragments_and_attachments
             if isinstance(attachment, Attachment)
         )
+        if ephemeral_fragments:
+            ephemeral_resolved = resolve_fragments(
+                db, ephemeral_fragments, allow_attachments=True
+            )
+            for item in ephemeral_resolved:
+                if isinstance(item, Fragment):
+                    item.ephemeral = True
+                    resolved_fragments.append(item)
+                elif isinstance(item, Attachment):
+                    resolved_attachments.append(item)
         resolved_system_fragments = resolve_fragments(db, system_fragments)
     except FragmentNotFound as ex:
         raise click.ClickException(str(ex))
@@ -942,6 +960,13 @@ def prompt(
     help="Fragment (alias, URL, hash or file path) to add to the prompt",
 )
 @click.option(
+    "ephemeral_fragments",
+    "-ef",
+    "--ephemeral-fragment",
+    multiple=True,
+    help="Fragment to add to the prompt without storing it",
+)
+@click.option(
     "system_fragments",
     "--sf",
     "--system-fragment",
@@ -1014,6 +1039,7 @@ def chat(
     _continue,
     conversation_id,
     fragments,
+    ephemeral_fragments,
     system_fragments,
     template,
     param,
@@ -1131,6 +1157,16 @@ def chat(
             for attachment in fragments_and_attachments
             if isinstance(attachment, Attachment)
         ]
+        if ephemeral_fragments:
+            ephemeral_resolved = resolve_fragments(
+                db, ephemeral_fragments, allow_attachments=True
+            )
+            for item in ephemeral_resolved:
+                if isinstance(item, Fragment):
+                    item.ephemeral = True
+                    argument_fragments.append(item)
+                elif isinstance(item, Attachment):
+                    argument_attachments.append(item)
         argument_system_fragments = resolve_fragments(db, system_fragments)
     except FragmentNotFound as ex:
         raise click.ClickException(str(ex))
@@ -1154,7 +1190,8 @@ def chat(
         attachments = []
         if argument_fragments:
             fragments += argument_fragments
-            # fragments from --fragments will get added to the first message only
+            # fragments from --fragment or --ephemeral-fragment are
+            # added to the first message only
             argument_fragments = []
         if argument_attachments:
             attachments = argument_attachments

--- a/llm/models.py
+++ b/llm/models.py
@@ -806,6 +806,8 @@ class _BaseResponse:
             for fragment in (previous_response.prompt.fragments or []) + (
                 previous_response.prompt.system_fragments or []
             ):
+                if getattr(fragment, "ephemeral", False):
+                    continue
                 fragment_id = ensure_fragment(db, fragment)
                 replacements[f"f:{fragment_id}"] = fragment
                 replacements[f"r:{previous_response.id}"] = (
@@ -813,6 +815,8 @@ class _BaseResponse:
                 )
 
         for i, fragment in enumerate(self.prompt.fragments):
+            if getattr(fragment, "ephemeral", False):
+                continue
             fragment_id = ensure_fragment(db, fragment)
             replacements[f"f{fragment_id}"] = fragment
             db["prompt_fragments"].insert(
@@ -823,6 +827,8 @@ class _BaseResponse:
                 },
             )
         for i, fragment in enumerate(self.prompt.system_fragments):
+            if getattr(fragment, "ephemeral", False):
+                continue
             fragment_id = ensure_fragment(db, fragment)
             replacements[f"f{fragment_id}"] = fragment
             db["system_fragments"].insert(

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -24,12 +24,21 @@ MIME_TYPE_FIXES = {
 
 class Fragment(str):
     def __new__(cls, content, *args, **kwargs):
-        # For immutable classes like str, __new__ creates the string object
+        """Create the underlying immutable string object."""
+
         return super().__new__(cls, content)
 
-    def __init__(self, content, source=""):
-        # Initialize our custom attributes
+    def __init__(self, content, source: str | None = "", ephemeral: bool = False):
+        """Initialize the fragment with optional metadata.
+
+        Args:
+            content: The fragment text.
+            source: Optional location the fragment was loaded from.
+            ephemeral: If ``True`` the fragment should not be persisted.
+        """
+
         self.source = source
+        self.ephemeral = ephemeral
 
     def id(self):
         return hashlib.sha256(self.encode("utf-8")).hexdigest()

--- a/llm_tools.py
+++ b/llm_tools.py
@@ -1,6 +1,7 @@
 import click
 import sqlite_utils
 
+
 @click.command("delete_all_fragments")
 def delete_all_fragments():
     """
@@ -16,23 +17,31 @@ def delete_all_fragments():
         click.echo(f"Deleted {deleted_count} rows from fragments table.")
 
         # Delete orphan rows in fragment_aliases table
-        db["fragment_aliases"].delete_where("fragment_id NOT IN (SELECT id FROM fragments)")
+        db["fragment_aliases"].delete_where(
+            "fragment_id NOT IN (SELECT id FROM fragments)"
+        )
 
         # Delete orphan rows in prompt_fragments table
-        db["prompt_fragments"].delete_where("fragment_id NOT IN (SELECT id FROM fragments)")
+        db["prompt_fragments"].delete_where(
+            "fragment_id NOT IN (SELECT id FROM fragments)"
+        )
 
         # Delete orphan rows in system_fragments table
-        db["system_fragments"].delete_where("fragment_id NOT IN (SELECT id FROM fragments)")
+        db["system_fragments"].delete_where(
+            "fragment_id NOT IN (SELECT id FROM fragments)"
+        )
 
         click.echo("Successfully deleted all fragments and orphan rows.")
     except Exception as ex:
         msg = f"Error deleting fragments: {ex}"
         raise click.ClickException(msg)
 
+
 # Add the command to the CLI
 @click.group()
 def cli():
     pass
+
 
 cli.add_command(delete_all_fragments)
 


### PR DESCRIPTION
## Summary
- add support for `-ef/--ephemeral-fragment` CLI option
- mark ephemeral fragments so they are not persisted
- skip ephemeral fragments when logging to the database
- document ephemeral fragments and note in changelog

## Testing
- `black .`
- `ruff check .`
- `mypy llm`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706d99c9d48324a4d35b11b55bf918